### PR TITLE
Fix remaining seat calculation

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -146,7 +146,7 @@ function info_populator (side, course_desc) {
     document.querySelector(`.${side} #exam`).innerHTML = course_desc["dayNo"];
     document.querySelector(`.${side} #avs`).innerHTML = course_desc["defaultSeatCapacity"];
     document.querySelector(`.${side} #sb`).innerHTML = course_desc["totalFillupSeat"];
-    document.querySelector(`.${side} #sr`).innerHTML = course_desc["availableSeat"];
+    document.querySelector(`.${side} #sr`).innerHTML = course_desc["defaultSeatCapacity"] - course_desc["totalFillupSeat"];
 }
 
 /*


### PR DESCRIPTION
Now matches with the USIS portal.

Not sure what's the purpose of `availableSeat` is but it's static and can also be more than `defaultSeatCapacity` too.